### PR TITLE
Bump service-loadbalancer timeouts from 50s to 180s

### DIFF
--- a/service-loadbalancer/template.cfg
+++ b/service-loadbalancer/template.cfg
@@ -3,7 +3,7 @@
 global
     daemon
     stats socket /tmp/haproxy
-    server-state-file global       
+    server-state-file global
     server-state-base /var/state/haproxy/
 
 {{ if eq .startSyslog "true" }}
@@ -19,47 +19,47 @@ global
 
 defaults
     log global
-   
+
     load-server-state-from-file global
-    
+
     # Enable session redistribution in case of connection failure.
     option redispatch
-    
-    # Disable logging of null connections (haproxy connections like checks). 
+
+    # Disable logging of null connections (haproxy connections like checks).
     # This avoids excessive logs from haproxy internals.
     option dontlognull
-    
+
     # Enable HTTP connection closing on the server side.
     option http-server-close
 
-    # Enable insertion of the X-Forwarded-For header to requests sent to 
+    # Enable insertion of the X-Forwarded-For header to requests sent to
     # servers and keep client IP address.
     option forwardfor
-    
+
     # Enable HTTP keep-alive from client to server.
     option http-keep-alive
 
     # Clients should send their full http request in 5s.
     timeout http-request    5s
-    
+
     # Maximum time to wait for a connection attempt to a server to succeed.
     timeout connect         5s
 
     # Maximum inactivity time on the client side.
     # Applies when the client is expected to acknowledge or send data.
-    timeout client          50s
+    timeout client          180s
 
     # Inactivity timeout on the client side for half-closed connections.
-    # Applies when the client is expected to acknowledge or send data 
+    # Applies when the client is expected to acknowledge or send data
     # while one direction is already shut down.
     timeout client-fin      50s
-    
+
     # Maximum inactivity time on the server side.
-    timeout server          50s
-    
+    timeout server          180s
+
     # timeout to use with WebSocket and CONNECT
     timeout tunnel          1h
-    
+
     # Maximum allowed time to wait for a new HTTP request to appear.
     timeout http-keep-alive 60s
 
@@ -93,7 +93,7 @@ frontend httpsfrontend
     {{ if $svc.AclMatch }} acl url_acl_{{$svc.Name}} path_beg {{$svc.AclMatch}}
     {{else}} acl url_acl_{{$svc.Name}} path_beg /{{$svc.Name}}
     {{ end }}
-    
+
     {{ if $svc.Host }}acl host_acl_{{$svc.Name}} hdr(host) {{$svc.Host}}
     use_backend {{$svc.Name}} if url_acl_{{$svc.Name}} or host_acl_{{$svc.Name}}
     {{ else }}use_backend {{$svc.Name}} if url_acl_{{$svc.Name}}
@@ -210,7 +210,7 @@ backend {{$svc.Name}}
     # create a stickiness table using client IP address as key
     # http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#stick-table
     stick-table type ip size 100k expire 30m
-    stick on src    
+    stick on src
 {{end}}
     {{range $j, $ep := $svc.Ep}}server {{$ep}} {{$ep}}
     {{end}}


### PR DESCRIPTION
This is the simplest solution to bumping the timeout.

The alternative would be to write some Go and pull the timeouts from annotations on the `Service`.